### PR TITLE
Add more inhibit sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Helper scripts for PinePhone and PinePhone Pro users
 
 By default, the script will make the phone sleep within 60 seconds, when the screen is turned off (sleep mode will not apply while the screen is on and will make the phone sleep for 30 seconds for the first time (if not interrupted by pressing the power button to wake the phone). It will then keep the phone awake for 30 seconds and, as long as the user does not interact with the device, put the phone immediately back to sleep mode for a longer time, in 30-second steps, up to a maximum of 10 minutes. If the screen is turned on, sleep time will reset to the initial value. You can change the durations directly at the top of the script. While the phone is sleeping, the RGB LED will light up constantly green and when it is awake for the short period of time, it will be a blinking red. The LED will be turned off, when the phone screen is enabled (for example by pressing the power button). When new notifications are available, the LED color will turn to blue (constant blue during sleep; blinking blue during wake-time).
 
+Any active suspend inhibitors (e.g.: some music players) will keep the phone awake until the inhibitor is deactivated.
+
 How to install and use:
 - Save the 'sleepwalk' script to /usr/local/bin
 - Disable deep sleep in your desktop managers settings such as phosh
@@ -16,8 +18,6 @@ How to install and use:
     - Copy the openrc service file 'sleepwalkrc' to '/etc/init.d'
     - Execute 'rc-update add sleepwalkrc' and 'service sleepwalkrc start' to enable and start the service
 
-Known issues:
-- Phone will go to sleep even if apps like for example a music player is playing in the background while the screen is turned off. It will however not sleep, if you are making a call.
-
 Dependencies:
 - rtcwake
+- systemd

--- a/sleepwalk
+++ b/sleepwalk
@@ -47,15 +47,41 @@ reset_wake_time() {
 	> /sys/class/rtc/rtc0/wakealarm
 }
 
-can_sleep() {
-	if [ "$(cat /sys/class/backlight/backlight/bl_power)" == 0 ] || [ !is_screen_on_or_inhibitor_active ] || [ "$(cat /sys/class/power_supply/axp20x-usb/online)" == "1" ]; then
+inhibit_sleep() {
+	# Inhibit sleep if backlight is on (bl_power equals zero when on)
+	if [ "$(cat /sys/class/backlight/backlight/bl_power)" == 0 ]; then
 		return 1
-	else
-		return 0
 	fi
+
+	# Inhibit sleep if USB power is active (PinePhone)
+	#if [ "$(cat /sys/class/power_supply/axp20x-usb/online)" == "1" ]; then
+	#    return 1
+	#fi
+
+	# Inhibit sleep if USB power is active (PinePhone Pro)
+	#if [ "$(cat /sys/class/power_supply/rk818-usb/present)" == "1" ]; then
+	#	return 1
+	#fi
+
+	# Inhibit sleep if USB power is active (PinePhone Keyboard Case)
+	if [ "$(cat /sys/class/power_supply/ip5xxx-usb/present)" == "1" ]; then
+		return 1
+	fi
+
+	# Inhibit sleep if an inhibiting application is active
+	if [ is_inhibitor_active == 1 ]; then
+		return 1
+	fi
+
+	# Inhibit sleep if a call is active
+	if [ is_call_active == 1 ]; then
+		return 1
+	fi
+
+	return 0
 }
 
-is_screen_on_or_inhibitor_active() {
+is_inhibitor_active() {
 	INHIBITORS=$(systemd-inhibit --list --no-legend \
 		| grep -e '[[:space:]]sleep[[:space:]]' \
 		| grep -e 'lock$')
@@ -64,7 +90,17 @@ is_screen_on_or_inhibitor_active() {
 		return 0
 	fi
 
-	return "$(cat /sys/class/backlight/backlight/bl_power)"
+	return 1
+}
+
+is_call_active() {
+	CALLS=$(mmcli -m any --voice-list-calls)
+
+	if [ "$CALLS" == "No calls were found" ]; then
+		return 0
+	fi
+
+	return 1
 }
 
 led_sleep() {
@@ -140,7 +176,7 @@ if [ "$1" == "start" ]; then
 	NOTIFICATION_WATCHER=$!
 
 	while [ -d "$LOCK_DIR" ]; do
-		while ! can_sleep; do
+		while ! inhibit_sleep; do
 			sleep 60
 		done
 
@@ -153,7 +189,7 @@ if [ "$1" == "start" ]; then
 			echo "Failed going to sleep, try again in $WAKE_SECS seconds ..." >&2
 			wait_for_notifications
 			schedule_wake_time
-			if ! can_sleep; then
+			if ! inhibit_sleep; then
 				break
 			fi
 		done

--- a/sleepwalk
+++ b/sleepwalk
@@ -63,46 +63,44 @@ is_call_active() {
 	CALLS=$(mmcli -m any --voice-list-calls)
 
 	if [ "$CALLS" == "No calls were found" ]; then
-		return 0
+		return 1
 	fi
 
-	return 1
+	return 0
 }
 
 inhibit_sleep() {
 	# Inhibit sleep if backlight is on (bl_power equals zero when on)
 	if [ "$(cat /sys/class/backlight/backlight/bl_power)" == 0 ]; then
-		return 1
+		return 0
 	fi
 
 	# Inhibit sleep if USB power is active (PinePhone)
 	#if [ "$(cat /sys/class/power_supply/axp20x-usb/online)" == "1" ]; then
-	#    return 1
+	#    return 0
 	#fi
 
 	# Inhibit sleep if USB power is active (PinePhone Pro)
 	#if [ "$(cat /sys/class/power_supply/rk818-usb/present)" == "1" ]; then
-	#	return 1
+	#	return 0
 	#fi
 
 	# Inhibit sleep if USB power is active (PinePhone Keyboard Case)
 	if [ "$(cat /sys/class/power_supply/ip5xxx-usb/present)" == "1" ]; then
-		return 1
+		return 0
 	fi
 
 	# Inhibit sleep if an inhibiting application is active
-	is_inhibitor_active
-	if [ $? == 1 ]; then
-		return 1
+	if is_inhibitor_active; then
+		return 0
 	fi
 
 	# Inhibit sleep if a call is active
-	is_call_active
-	if [ $? == 1 ]; then
-		return 1
+	if is_call_active; then
+		return 0
 	fi
 
-	return 0
+	return 1
 }
 
 led_sleep() {
@@ -178,7 +176,17 @@ if [ "$1" == "start" ]; then
 	NOTIFICATION_WATCHER=$!
 
 	while [ -d "$LOCK_DIR" ]; do
-		while ! inhibit_sleep; do
+		# while true; do
+		# 	if inhibit_sleep; then
+		# 		echo "sleep inhibited"
+		# 	else
+		# 		echo "sleep not inhibited"
+		# 	fi
+
+		# 	sleep 1
+		# done
+
+		while inhibit_sleep; do
 			sleep 60
 		done
 
@@ -191,7 +199,7 @@ if [ "$1" == "start" ]; then
 			echo "Failed going to sleep, try again in $WAKE_SECS seconds ..." >&2
 			wait_for_notifications
 			schedule_wake_time
-			if ! inhibit_sleep; then
+			if inhibit_sleep; then
 				break
 			fi
 		done

--- a/sleepwalk
+++ b/sleepwalk
@@ -48,11 +48,23 @@ reset_wake_time() {
 }
 
 can_sleep() {
-	if [ "$(cat /sys/class/backlight/backlight/bl_power)" == 0 ] || [ "$(cat /sys/class/power_supply/axp20x-usb/online)" == "1" ]; then
+	if [ "$(cat /sys/class/backlight/backlight/bl_power)" == 0 ] || [ !is_screen_on_or_inhibitor_active ] || [ "$(cat /sys/class/power_supply/axp20x-usb/online)" == "1" ]; then
 		return 1
 	else
 		return 0
 	fi
+}
+
+is_screen_on_or_inhibitor_active() {
+	INHIBITORS=$(systemd-inhibit --list --no-legend \
+		| grep -e '[[:space:]]sleep[[:space:]]' \
+		| grep -e 'lock$')
+
+	if [ "$INHIBITORS" != "" ]; then
+		return 0
+	fi
+
+	return "$(cat /sys/class/backlight/backlight/bl_power)"
 }
 
 led_sleep() {

--- a/sleepwalk
+++ b/sleepwalk
@@ -47,6 +47,28 @@ reset_wake_time() {
 	> /sys/class/rtc/rtc0/wakealarm
 }
 
+is_inhibitor_active() {
+	INHIBITORS=$(systemd-inhibit --list --no-legend \
+		| grep -e '[[:space:]]sleep[[:space:]]' \
+		| grep -e 'lock$')
+
+	if [ "$INHIBITORS" != "" ]; then
+		return 0
+	fi
+
+	return 1
+}
+
+is_call_active() {
+	CALLS=$(mmcli -m any --voice-list-calls)
+
+	if [ "$CALLS" == "No calls were found" ]; then
+		return 0
+	fi
+
+	return 1
+}
+
 inhibit_sleep() {
 	# Inhibit sleep if backlight is on (bl_power equals zero when on)
 	if [ "$(cat /sys/class/backlight/backlight/bl_power)" == 0 ]; then
@@ -81,28 +103,6 @@ inhibit_sleep() {
 	fi
 
 	return 0
-}
-
-is_inhibitor_active() {
-	INHIBITORS=$(systemd-inhibit --list --no-legend \
-		| grep -e '[[:space:]]sleep[[:space:]]' \
-		| grep -e 'lock$')
-
-	if [ "$INHIBITORS" != "" ]; then
-		return 0
-	fi
-
-	return 1
-}
-
-is_call_active() {
-	CALLS=$(mmcli -m any --voice-list-calls)
-
-	if [ "$CALLS" == "No calls were found" ]; then
-		return 0
-	fi
-
-	return 1
 }
 
 led_sleep() {

--- a/sleepwalk
+++ b/sleepwalk
@@ -69,12 +69,14 @@ inhibit_sleep() {
 	fi
 
 	# Inhibit sleep if an inhibiting application is active
-	if [ is_inhibitor_active == 1 ]; then
+	is_inhibitor_active
+	if [ $? == 1 ]; then
 		return 1
 	fi
 
 	# Inhibit sleep if a call is active
-	if [ is_call_active == 1 ]; then
+	is_call_active
+	if [ $? == 1 ]; then
 		return 1
 	fi
 

--- a/sleepwalk
+++ b/sleepwalk
@@ -15,29 +15,6 @@ start_deep_sleep() {
 	return $?
 }
 
-wait_for_notifications() {
-	secs=$WAKE_SECS
-	is_led_on=0
-	while [ $secs -ge 0 ]; do
-		sleep 1
-		if [ $is_led_on == 0 ]; then
-			led_wake
-			is_led_on=1
-		else
-			led_disable
-			is_led_on=0
-		fi
-
-		if ! can_sleep; then
-			SLEEP_SECS=$SLEEP_SECS_INIT
-			break
-		fi
-		check_notifications
-		secs=$(($secs-1))
-	done
-	led_disable
-}
-
 schedule_wake_time() {
 	rtcwake -m no --date "+${SLEEP_SECS}s" 2>&1 >/dev/null
 }
@@ -60,13 +37,13 @@ is_inhibitor_active() {
 }
 
 is_call_active() {
-	CALLS=$(mmcli -m any --voice-list-calls)
+	CALLS=$(mmcli -m any --voice-list-calls | grep 'freedesktop')
 
-	if [ "$CALLS" == "No calls were found" ]; then
-		return 1
+	if [ "$CALLS" != "" ]; then
+		return 0
 	fi
 
-	return 0
+	return 1
 }
 
 inhibit_sleep() {
@@ -148,6 +125,28 @@ check_notifications() {
 	fi
 }
 
+wait_for_notifications() {
+	secs=$WAKE_SECS
+	is_led_on=0
+	while [ $secs -ge 0 ]; do
+		sleep 1
+		if [ $is_led_on == 0 ]; then
+			led_wake
+			is_led_on=1
+		else
+			led_disable
+			is_led_on=0
+		fi
+
+		if inhibit_sleep; then
+			SLEEP_SECS=$SLEEP_SECS_INIT
+			break
+		fi
+		check_notifications
+		secs=$(($secs-1))
+	done
+	led_disable
+}
 
 if [ $EUID -ne 0 ]; then
 	echo "Needs root" >&2


### PR DESCRIPTION
This is probably not ready to merge as I did a lot of rework as well as pulled in @XaviDCR92's systemd inhibitor PR.  I was using Xavi's version of sleepwalk for several weeks and one issue I kept running into is that it would sleep in the middle of a call.  Phosh seems to turn off the screen during calls.  I added a check for calls using modemmanager (mmcli -m any --voice-list-calls).  If there is a call it displays a path which includes "freedesktop" so I'm checking for that string.  If no calls are present, it has a message indicating no calls and if the modem is offline (which happens when waking from suspend) it has an error, so grepping for "freedesktop" handles all those cases.

I also added suspend sources for the PinePhone, Pro, and Keyboard power supplies, though commented all out except keyboard because that's what I'm using.  An enhancement would be to test which paths exist and automatically use the correct one (with keyboard taking priority over the phone specific ones, as the phone's power supply will report online when the keyboard battery is charging the phone).

I tested the call functionality by turning off the screen and leaving the call active for 2 minutes, the PinePhone did not sleep.